### PR TITLE
Harden registration, OAuth, and production auth secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,15 +110,18 @@ Copy `.env.example` to `.env` in both `backend/` and `frontend/`, then fill in v
 | Variable | Purpose |
 |----------|---------|
 | `DATABASE_URL` | Optional. Defaults to SQLite `instance/app.db` |
-| `SECRET_KEY` / `JWT_SECRET_KEY` | Flask session + JWT signing keys |
+| `SECRET_KEY` / `JWT_SECRET_KEY` | Flask session + JWT signing keys. Both are mandatory in production; use independent, high-entropy values. |
 | Social auth vars | `GOOGLE_...`, `GITHUB_...`, `FACEBOOK_...` enable OAuth sign-in |
-| `SOCIAL_DEFAULT_REDIRECT` | Backend fallback redirect (default `http://localhost:5173/auth/callback`) |
+| `SOCIAL_DEFAULT_REDIRECT` | Backend fallback redirect. It must also appear in `OAUTH_REDIRECT_ALLOWLIST`. |
+| `OAUTH_REDIRECT_ALLOWLIST` | Comma-separated, exact frontend OAuth callback URLs. Production deployments must list every trusted frontend callback explicitly. |
 | `VITE_API_BASE` | Frontend base URL for the API (default `http://localhost:5000`) |
 | `VITE_SOCIAL_AUTH_CALLBACK_URL` | Frontend callback URL (default `http://localhost:5173/auth/callback`) |
 
 ```bash
 cp .env.example .env
 ```
+
+OAuth provider callbacks issue a short-lived, single-use exchange code. The frontend exchanges that code for a JWT through `/auth/oauth/exchange`; JWTs are never placed in redirect query strings.
 
 ---
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -31,8 +31,24 @@ def create_app():
 
     app.config["SQLALCHEMY_DATABASE_URI"] = db_url
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-    app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "dev-secret-key")
-    app.config["JWT_SECRET_KEY"] = os.getenv("JWT_SECRET_KEY", "jwt-secret")
+    environment = os.getenv("FLASK_ENV", "development").lower()
+    is_production = environment == "production" or os.getenv("RENDER", "").lower() == "true"
+
+    secret_key = os.getenv("SECRET_KEY")
+    jwt_secret_key = os.getenv("JWT_SECRET_KEY")
+    if is_production and (not secret_key or not jwt_secret_key):
+        missing = [
+            name
+            for name, value in (("SECRET_KEY", secret_key), ("JWT_SECRET_KEY", jwt_secret_key))
+            if not value
+        ]
+        raise RuntimeError(f"Missing required production secrets: {', '.join(missing)}")
+
+    app.config["SECRET_KEY"] = secret_key or "dev-secret-key"
+    app.config["JWT_SECRET_KEY"] = jwt_secret_key or "jwt-secret"
+    app.config["SESSION_COOKIE_HTTPONLY"] = True
+    app.config["SESSION_COOKIE_SECURE"] = is_production
+    app.config["SESSION_COOKIE_SAMESITE"] = "None" if is_production else "Lax"
 
     db.init_app(app)
     migrate.init_app(app, db)
@@ -51,6 +67,17 @@ def create_app():
         "SOCIAL_DEFAULT_REDIRECT",
         os.getenv("SOCIAL_DEFAULT_REDIRECT", "http://localhost:5173/auth/callback"),
     )
+    configured_redirects = os.getenv("OAUTH_REDIRECT_ALLOWLIST", "")
+    app.config["OAUTH_REDIRECT_ALLOWLIST"] = {
+        url.strip().rstrip("/")
+        for url in configured_redirects.split(",")
+        if url.strip()
+    } or {
+        "http://localhost:5173/auth/callback",
+        "http://127.0.0.1:5173/auth/callback",
+        "https://moringadesk-gcvu.onrender.com/auth/callback",
+        "https://moringadesk-gteo.onrender.com/auth/callback",
+    }
     register_oauth_clients(app)
 
     # --- CORS ---

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -2,9 +2,10 @@ import base64
 import json
 import secrets
 import datetime
+import time
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
-from flask import Blueprint, request, jsonify, current_app, redirect, url_for
+from flask import Blueprint, request, jsonify, current_app, redirect, url_for, session
 from flask_cors import cross_origin
 from flask_jwt_extended import create_access_token, jwt_required, get_jwt_identity
 
@@ -32,15 +33,18 @@ def register():
     name = data.get("name")
     email = data.get("email")
     password = data.get("password")
-    role = data.get("role", "student")  # default = student
+    requested_role = data.get("role")
 
     if not name or not email or not password:
         return jsonify({"error": "Name, email, and password are required"}), 400
 
+    if requested_role not in (None, "student"):
+        return jsonify({"error": "Role cannot be assigned during public registration"}), 400
+
     if User.query.filter_by(email=email).first():
         return jsonify({"error": "Email already registered"}), 400
 
-    user = User(name=name, email=email, role=role)
+    user = User(name=name, email=email, role="student")
     user.set_password(password)
 
     db.session.add(user)
@@ -120,13 +124,11 @@ def _decode_state(raw):
 
 def _safe_redirect_url(candidate):
     default_url = current_app.config.get("SOCIAL_DEFAULT_REDIRECT")
-    if not candidate:
-        return default_url
-
-    parsed = urlparse(candidate)
-    if parsed.scheme in {"http", "https"} and parsed.netloc:
+    allowed = current_app.config.get("OAUTH_REDIRECT_ALLOWLIST", set())
+    normalized = candidate.rstrip("/") if candidate else None
+    if normalized in allowed:
         return candidate
-    return default_url
+    return default_url if default_url and default_url.rstrip("/") in allowed else next(iter(allowed), None)
 
 
 def _append_query_params(url, params):
@@ -287,15 +289,45 @@ def oauth_callback(provider):
         )
         return redirect(error_redirect)
 
-    access_token = create_access_token(identity=str(user.id), expires_delta=datetime.timedelta(hours=1))
-
+    exchange_code = secrets.token_urlsafe(32)
+    session["oauth_exchange"] = {
+        "code": exchange_code,
+        "user_id": user.id,
+        "expires_at": int(time.time()) + 90,
+    }
     success_redirect = _append_query_params(
         redirect_url,
         {
-            "token": access_token,
+            "code": exchange_code,
             "provider": provider,
             "intent": intent,
             "state": frontend_state,
         },
     )
     return redirect(success_redirect)
+
+
+@auth_bp.route("/oauth/exchange", methods=["POST", "OPTIONS"])
+@cross_origin(supports_credentials=True)
+def oauth_exchange():
+    if request.method == "OPTIONS":
+        return _handle_preflight()
+
+    supplied_code = (request.get_json() or {}).get("code")
+    exchange = session.pop("oauth_exchange", None)
+    if (
+        not supplied_code
+        or not exchange
+        or exchange.get("expires_at", 0) < int(time.time())
+        or not secrets.compare_digest(supplied_code, exchange.get("code", ""))
+    ):
+        return jsonify({"error": "Invalid or expired OAuth exchange code"}), 401
+
+    user = db.session.get(User, exchange.get("user_id"))
+    if not user:
+        return jsonify({"error": "User not found"}), 404
+
+    access_token = create_access_token(
+        identity=str(user.id), expires_delta=datetime.timedelta(hours=1)
+    )
+    return jsonify({"access_token": access_token, "user": user.to_dict()}), 200

--- a/backend/app/schemas/user_schema.py
+++ b/backend/app/schemas/user_schema.py
@@ -13,7 +13,7 @@ class UserRegistrationSchema(Schema):
     name = fields.Str(required=True, validate=validate.Length(min=1, max=100))
     email = fields.Email(required=True, validate=validate.Length(max=255))
     password = fields.Str(required=True, validate=validate.Length(min=6))
-    role = fields.Str(missing='student', validate=validate.OneOf(['student', 'admin']))
+    role = fields.Str(load_only=True, validate=validate.Equal('student'))
     
     @validates_schema
     def validate_email_unique(self, data, **kwargs):

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -19,7 +19,7 @@ class AuthService:
         user = User(
             name=validated['name'],
             email=validated['email'],
-            role=validated.get('role', 'user')
+            role='student'
         )
         user.set_password(validated['password'])
         db.session.add(user)

--- a/backend/env.example
+++ b/backend/env.example
@@ -1,5 +1,7 @@
 SECRET_KEY=dev-secret-key-change-in-production
 JWT_SECRET_KEY=jwt-secret-string
+OAUTH_REDIRECT_ALLOWLIST=http://localhost:5173/auth/callback,http://127.0.0.1:5173/auth/callback
+SOCIAL_DEFAULT_REDIRECT=http://localhost:5173/auth/callback
 DATABASE_URL=sqlite:///moringadesk.db
 FLASK_ENV=development
 FLASK_DEBUG=True

--- a/backend/tests/test_auth_security.py
+++ b/backend/tests/test_auth_security.py
@@ -1,0 +1,134 @@
+import datetime
+import time
+
+from flask_jwt_extended import create_access_token
+
+from app import db
+from app.models.user import User
+from app.routes.auth import _safe_redirect_url
+
+
+def _register(client, email="student@example.com", **extra):
+    payload = {
+        "name": "Student User",
+        "email": email,
+        "password": "secret123",
+        **extra,
+    }
+    return client.post("/auth/register", json=payload)
+
+
+def test_public_registration_rejects_admin_role(client):
+    response = _register(client, email="no-admin@example.com", role="admin")
+
+    assert response.status_code == 400
+    assert "role" in response.get_json()["error"].lower()
+    assert User.query.filter_by(email="no-admin@example.com").first() is None
+
+
+def test_public_registration_rejects_unknown_role(client):
+    response = _register(client, email="no-owner@example.com", role="owner")
+
+    assert response.status_code == 400
+    assert User.query.filter_by(email="no-owner@example.com").first() is None
+
+
+def test_public_registration_always_creates_student(client):
+    response = _register(client, email="student-only@example.com", role="student")
+
+    assert response.status_code == 201
+    assert response.get_json()["user"]["role"] == "student"
+
+
+def test_unsafe_oauth_redirect_falls_back_to_allowlisted_url(app):
+    with app.test_request_context():
+        app.config["SOCIAL_DEFAULT_REDIRECT"] = "http://localhost:5173/auth/callback"
+        app.config["OAUTH_REDIRECT_ALLOWLIST"] = {
+            "http://localhost:5173/auth/callback"
+        }
+
+        assert _safe_redirect_url("https://attacker.example/steal") == (
+            "http://localhost:5173/auth/callback"
+        )
+        assert _safe_redirect_url("http://localhost:5173/auth/callback") == (
+            "http://localhost:5173/auth/callback"
+        )
+
+
+def test_student_cannot_access_admin_routes(client):
+    registration = _register(client, email="ordinary@example.com")
+    token = registration.get_json()["access_token"]
+
+    response = client.get(
+        "/admin/users", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert response.status_code == 403
+
+
+def test_admin_route_rejects_missing_jwt(client):
+    assert client.get("/admin/users").status_code == 401
+
+
+def test_expired_jwt_is_rejected(client, app):
+    with app.app_context():
+        token = create_access_token(
+            identity="1", expires_delta=datetime.timedelta(seconds=-1)
+        )
+
+    response = client.get(
+        "/auth/me", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert response.status_code == 401
+
+
+def test_invalid_jwt_is_rejected(client):
+    response = client.get(
+        "/auth/me", headers={"Authorization": "Bearer not-a-valid-jwt"}
+    )
+
+    assert response.status_code == 422
+
+
+def test_oauth_exchange_rejects_invalid_and_expired_codes(client):
+    with client.session_transaction() as oauth_session:
+        oauth_session["oauth_exchange"] = {
+            "code": "expected-code",
+            "user_id": 1,
+            "expires_at": int(time.time()) + 60,
+        }
+    assert client.post(
+        "/auth/oauth/exchange", json={"code": "wrong-code"}
+    ).status_code == 401
+
+    with client.session_transaction() as oauth_session:
+        oauth_session["oauth_exchange"] = {
+            "code": "expired-code",
+            "user_id": 1,
+            "expires_at": int(time.time()) - 1,
+        }
+    assert client.post(
+        "/auth/oauth/exchange", json={"code": "expired-code"}
+    ).status_code == 401
+
+
+def test_oauth_exchange_is_single_use(client):
+    user = User(name="OAuth User", email="oauth@example.com", role="student")
+    user.set_password("unused-password")
+    db.session.add(user)
+    db.session.commit()
+
+    with client.session_transaction() as oauth_session:
+        oauth_session["oauth_exchange"] = {
+            "code": "one-time-code",
+            "user_id": user.id,
+            "expires_at": int(time.time()) + 60,
+        }
+
+    first = client.post("/auth/oauth/exchange", json={"code": "one-time-code"})
+    second = client.post("/auth/oauth/exchange", json={"code": "one-time-code"})
+
+    assert first.status_code == 200
+    assert first.get_json()["access_token"]
+    assert second.status_code == 401

--- a/backend/tests/test_problems_and_solutions.py
+++ b/backend/tests/test_problems_and_solutions.py
@@ -35,7 +35,7 @@ def _auth_register_and_login(client, email="admin@moringa.test", password="secre
     # Register (ignore status; some backends may return 409 if already exists)
     client.post(
         "/auth/register",
-        json={"name": name, "email": email, "password": password, "role": "admin"},
+        json={"name": name, "email": email, "password": password},
     )
     # Login
     r = client.post("/auth/login", json={"email": email, "password": password})

--- a/frontend/src/components/SocialAuthCallback.jsx
+++ b/frontend/src/components/SocialAuthCallback.jsx
@@ -16,8 +16,7 @@ export function SocialAuthCallback({ onComplete }) {
 
   useEffect(() => {
     const errorParam = params.get("error");
-    const token =
-      params.get("token") || params.get("access_token") || params.get("accessToken");
+    const code = params.get("code");
 
     if (errorParam) {
       setStatus("error");
@@ -25,18 +24,16 @@ export function SocialAuthCallback({ onComplete }) {
       return;
     }
 
-    if (!token) {
+    if (!code) {
       setStatus("error");
-      setMessage("Missing access token from the provider. Please try signing in again.");
+      setMessage("Missing sign-in exchange code. Please try signing in again.");
       return;
     }
 
-    localStorage.setItem("access_token", token);
-
     (async () => {
       try {
-        const me = await authApi.me();
-        const user = me.user ?? me;
+        const result = await authApi.exchangeOAuthCode(code);
+        const user = result.user;
         setStatus("success");
         setMessage(`You're in! Redirecting to your ${user.role} workspace.`);
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -33,6 +33,7 @@ export function buildSocialAuthUrl(provider, options = {}) {
 const api = axios.create({
   baseURL: API_BASE,
   timeout: 15000,
+  withCredentials: true,
 });
 
 // ✅ Attach token automatically if it exists
@@ -99,6 +100,12 @@ export const authApi = {
 
   login: (email, password) =>
     api.post("/auth/login", { email, password }).then((r) => {
+      if (r.data.access_token) storeToken(r.data.access_token);
+      return r.data;
+    }),
+
+  exchangeOAuthCode: (code) =>
+    api.post("/auth/oauth/exchange", { code }).then((r) => {
       if (r.data.access_token) storeToken(r.data.access_token);
       return r.data;
     }),


### PR DESCRIPTION
## Summary

- force all public registrations to create the default `student` role and reject elevated or unknown role input
- replace permissive OAuth redirects with an exact `OAUTH_REDIRECT_ALLOWLIST`
- remove JWTs from OAuth callback query strings and use a 90-second, session-bound, single-use exchange code
- require `SECRET_KEY` and `JWT_SECRET_KEY` in production while preserving development fallbacks
- add focused regression coverage for registration roles, redirect validation, admin authorization, invalid/expired JWTs, and OAuth exchange edge cases
- document the new production secret and OAuth redirect configuration

## Security rationale

The previous public registration endpoint trusted the caller's `role`, allowing an unauthenticated user to create an administrator account. OAuth accepted any absolute HTTP(S) redirect and appended the JWT to that URL, exposing tokens to an attacker-controlled destination as well as browser history and intermediary logs. Production also fell back to predictable signing secrets when environment variables were missing.

This change closes those paths while retaining the existing frontend JWT flow: the OAuth callback now places only a short-lived, one-time code in the trusted frontend callback URL, and the frontend exchanges it directly with the API before storing the returned JWT as it already does for password login.

## Validation

- GitHub Actions CI run **#109 passed**, including the repository's configured backend test suite
- `python -m py_compile` passed locally for every modified backend module and test file
- branch diff reviewed: 10 intended files, based directly on `main`
- local `pytest` dependency installation was blocked by package-source latency; the clean GitHub Actions run is the authoritative suite result

## Deployment notes

Production must define independent high-entropy `SECRET_KEY` and `JWT_SECRET_KEY` values. Configure `OAUTH_REDIRECT_ALLOWLIST` as a comma-separated list of exact trusted callback URLs, and ensure `SOCIAL_DEFAULT_REDIRECT` is one of them.